### PR TITLE
Fix item removal

### DIFF
--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -608,6 +608,9 @@ extern u8 gEnemyPartyCount;
 extern struct Pokemon gEnemyParty[PARTY_SIZE];
 extern struct SpriteTemplate gMultiuseSpriteTemplate;
 extern u16 gFollowerSteps;
+extern bool32 consumeItem;
+extern u32 removeBagItem;
+extern u32 removeBagItemCount;
 
 extern const u8 gFacilityClassToPicIndex[];
 extern const u8 gFacilityClassToTrainerClass[];
@@ -810,5 +813,6 @@ u32 CheckDynamicMoveType(struct Pokemon *mon, u32 move, u32 battler);
 uq4_12_t GetDynamaxLevelHPMultiplier(u32 dynamaxLevel, bool32 inverseMultiplier);
 u32 GetRegionalFormByRegion(u32 species, u32 region);
 bool32 IsSpeciesForeignRegionalForm(u32 species, u32 currentRegion);
+void DoRemoveItems(struct Pokemon *mon);
 
 #endif // GUARD_POKEMON_H

--- a/src/evolution_scene.c
+++ b/src/evolution_scene.c
@@ -820,7 +820,10 @@ static void Task_EvolutionScene(u8 taskId)
                 Overworld_PlaySpecialMapMusic();
             }
             if (!gTasks[taskId].tEvoWasStopped)
+            {
+                DoRemoveItems(mon);
                 CreateShedinja(gTasks[taskId].tPreEvoSpecies, mon);
+            }
 
             DestroyTask(taskId);
             FreeMonSpritesGfx();

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -90,6 +90,9 @@ EWRAM_DATA struct SpriteTemplate gMultiuseSpriteTemplate = {0};
 EWRAM_DATA static struct MonSpritesGfxManager *sMonSpritesGfxManagers[MON_SPR_GFX_MANAGERS_COUNT] = {NULL};
 EWRAM_DATA static u8 sTriedEvolving = 0;
 EWRAM_DATA u16 gFollowerSteps = 0;
+EWRAM_DATA bool32 removeHeldItem = 0;
+EWRAM_DATA u32 removeBagItem = 0;
+EWRAM_DATA u32 removeBagItemCount = 0;
 
 #include "data/abilities.h"
 
@@ -4436,6 +4439,18 @@ u8 GetNatureFromPersonality(u32 personality)
     return personality % NUM_NATURES;
 }
 
+void DoRemoveItems(struct Pokemon *mon)
+{
+    if (removeHeldItem)
+    {
+        u32 heldItem = ITEM_NONE;
+        SetMonData(mon, MON_DATA_HELD_ITEM, &heldItem);
+    }
+
+    if (removeBagItem != ITEM_NONE && removeBagItemCount != 0)
+        RemoveBagItem(removeBagItem, removeBagItemCount);
+}
+
 u32 GetGMaxTargetSpecies(u32 species)
 {
     const struct FormChange *formChanges = GetSpeciesFormChanges(species);
@@ -4460,7 +4475,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
     u8 beauty = GetMonData(mon, MON_DATA_BEAUTY, 0);
     u16 upperPersonality = personality >> 16;
     u32 holdEffect, currentMap, partnerSpecies, partnerHeldItem, partnerHoldEffect;
-    bool32 consumeItem = FALSE;
+    removeHeldItem = FALSE;
     u16 evolutionTracker = GetMonData(mon, MON_DATA_EVOLUTION_TRACKER, 0);
     const struct Evolution *evolutions = GetSpeciesEvolutions(species);
 
@@ -4541,14 +4556,14 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
                 if (GetTimeOfDay() == TIME_NIGHT && heldItem == evolutions[i].param)
                 {
                     targetSpecies = evolutions[i].targetSpecies;
-                    consumeItem = TRUE;
+                    removeHeldItem = TRUE;
                 }
                 break;
             case EVO_ITEM_HOLD_DAY:
                 if (GetTimeOfDay() != TIME_NIGHT && heldItem == evolutions[i].param)
                 {
                     targetSpecies = evolutions[i].targetSpecies;
-                    consumeItem = TRUE;
+                    removeHeldItem = TRUE;
                 }
                 break;
             case EVO_LEVEL_DUSK:
@@ -4728,7 +4743,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
                 if (heldItem == evolutions[i].param)
                 {
                     targetSpecies = evolutions[i].targetSpecies;
-                    consumeItem = TRUE;
+                    removeHeldItem = TRUE;
                 }
                 break;
             case EVO_USE_MOVE_TWENTY_TIMES:
@@ -4769,7 +4784,8 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
                 if (CheckBagHasItem(evolutions[i].param, 999))
                 {
                     targetSpecies = evolutions[i].targetSpecies;
-                    RemoveBagItem(evolutions[i].param, 999);
+                    removeBagItem = evolutions[i].param;
+                    removeBagItemCount = 999;
                 }
                 break;
             }
@@ -4790,7 +4806,7 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
                 if (evolutions[i].param == heldItem)
                 {
                     targetSpecies = evolutions[i].targetSpecies;
-                    consumeItem = TRUE;
+                    removeHeldItem = TRUE;
                 }
                 break;
             case EVO_TRADE_SPECIFIC_MON:
@@ -4875,40 +4891,20 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
                     targetSpecies = evolutions[i].targetSpecies;
                 break;
             case EVO_ITEM_HOLD_SPIN_DAY_LESS_THAN_5_SECS_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_DAY_LESS_THAN_5_SECS_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_DAY_LESS_THAN_5_SECS_COUNTER_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_DAY_LESS_THAN_5_SECS_COUNTER_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_NIGHT_LESS_THAN_5_SECS_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_NIGHT_LESS_THAN_5_SECS_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_NIGHT_LESS_THAN_5_SECS_COUNTER_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_NIGHT_LESS_THAN_5_SECS_COUNTER_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_DAY_MORE_THAN_5_SECS_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_DAY_MORE_THAN_5_SECS_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_DAY_MORE_THAN_5_SECS_COUNTER_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_DAY_MORE_THAN_5_SECS_COUNTER_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_NIGHT_MORE_THAN_5_SECS_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_NIGHT_MORE_THAN_5_SECS_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_NIGHT_MORE_THAN_5_SECS_COUNTER_CLOCKWISE:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_NIGHT_MORE_THAN_5_SECS_COUNTER_CLOCKWISE)
-                    targetSpecies = evolutions[i].targetSpecies;
-                break;
             case EVO_ITEM_HOLD_SPIN_DUSK_MORE_THAN_10_SECS:
-                if (evolutions[i].param == heldItem && evolutionItem == EVO_ITEM_HOLD_SPIN_DUSK_MORE_THAN_10_SECS)
+                if (evolutions[i].param == heldItem && evolutionItem == evolutions[i].method)
+                {
                     targetSpecies = evolutions[i].targetSpecies;
+                    removeHeldItem = TRUE;
+                }
+                    
                 break;
             }
         }
@@ -4923,12 +4919,6 @@ u16 GetEvolutionTargetSpecies(struct Pokemon *mon, enum EvolutionMode mode, u16 
      && GetGMaxTargetSpecies(targetSpecies) == targetSpecies)
     {
         return SPECIES_NONE;
-    }
-
-    if (consumeItem)
-    {
-        heldItem = ITEM_NONE;
-        SetMonData(mon, MON_DATA_HELD_ITEM, &heldItem);
     }
 
     return targetSpecies;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes item removal so it happens after the evolution scene has finished

## Description
a quick change to how item removing is handled so that if the evo can be canceled and is, no items are removed, otherwise removes held items and bag items correctly.

also consolidates the alcremie evolution cases, as a treat

## **Discord contact info**
@khbsd
